### PR TITLE
feat: add embedded message codes and tests

### DIFF
--- a/config/messagecode/catalog/message_codes.json
+++ b/config/messagecode/catalog/message_codes.json
@@ -1,0 +1,926 @@
+[
+  {
+    "id": 120,
+    "code": 104001,
+    "message": "Verification failed",
+    "http_code": 401,
+    "locale": "en"
+  },
+  {
+    "id": 2,
+    "code": 102001,
+    "message": "Bạn vừa thực hiện tạo thành công %s",
+    "http_code": 200,
+    "locale": "vi"
+  },
+  {
+    "id": 79,
+    "code": 105100,
+    "message": "Invalid return format",
+    "http_code": 500,
+    "locale": "en"
+  },
+  {
+    "id": 121,
+    "code": 104001,
+    "message": "Request denied",
+    "http_code": 401,
+    "locale": "en"
+  },
+  {
+    "id": 17,
+    "code": 104001,
+    "message": "Yêu cầu bị từ chối",
+    "http_code": 401,
+    "locale": "vi"
+  },
+  {
+    "id": 1,
+    "code": 102000,
+    "message": "Thực thi API thành công",
+    "http_code": 200,
+    "locale": "vi"
+  },
+  {
+    "id": 85,
+    "code": 105000,
+    "message": "System error",
+    "http_code": 500,
+    "locale": "en"
+  },
+  {
+    "id": 122,
+    "code": 104000,
+    "message": "Invalid request",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 109,
+    "code": 104100,
+    "message": "Duplicate information",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 10,
+    "code": 104001,
+    "message": "Xác thực không thành công",
+    "http_code": 401,
+    "locale": "vi"
+  },
+  {
+    "id": 110,
+    "code": 104004,
+    "message": "Information not found",
+    "http_code": 404,
+    "locale": "en"
+  },
+  {
+    "id": 70,
+    "code": 102001,
+    "message": "You have successfully created %s.",
+    "http_code": 200,
+    "locale": "en"
+  },
+  {
+    "id": 16,
+    "code": 104000,
+    "message": "Yêu cầu không hợp lệ",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 20,
+    "code": 105100,
+    "message": "Định dạng trả về không hợp lệ",
+    "http_code": 500,
+    "locale": "vi"
+  },
+  {
+    "id": 15,
+    "code": 105000,
+    "message": "Lỗi hệ thống",
+    "http_code": 500,
+    "locale": "vi"
+  },
+  {
+    "id": 19,
+    "code": 104100,
+    "message": "Thông tin bị trùng lặp",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 18,
+    "code": 104004,
+    "message": "Thông tin không tìm thấy",
+    "http_code": 404,
+    "locale": "vi"
+  },
+  {
+    "id": 81,
+    "code": 224008,
+    "message": "This withdrawal transaction has been canceled",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 181,
+    "code": 224011,
+    "message": "Otp is invalid.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 182,
+    "code": 224011,
+    "message": "Otp xác thực không đúng.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 80,
+    "code": 224006,
+    "message": "Your business has not registered for this service yet. Please contact Support for further assistance",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 82,
+    "code": 224002,
+    "message": "Supplier code not found",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 183,
+    "code": 224011,
+    "message": "Otp is invalid",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 104,
+    "code": 224007,
+    "message": "Your linked account does not support withdrawals",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 25,
+    "code": 224007,
+    "message": "Tài khoản liên kết của bạn chưa hỗ trợ rút tiền",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 105,
+    "code": 224010,
+    "message": "Linked account is incorrect",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 74,
+    "code": 224005,
+    "message": "An error occurred at the issuing bank",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 106,
+    "code": 224009,
+    "message": "Beneficiary account is invalid",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 12,
+    "code": 224002,
+    "message": "Không tìm thấy mã nhà cung cấp",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 184,
+    "code": 224011,
+    "message": "OTP is invalid!",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 185,
+    "code": 224011,
+    "message": "OTP is invalid",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 186,
+    "code": 224011,
+    "message": "OTP xác thực không đúng",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 13,
+    "code": 224001,
+    "message": "The amount is below the minimum or exceeds the maximum threshold",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 100,
+    "code": 224001,
+    "message": "Transaction amount is below the minimum limit",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 22,
+    "code": 224005,
+    "message": "Có lỗi xảy ra ở ngân hàng phát hành",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 24,
+    "code": 224006,
+    "message": "Doanh nghiệp của bạn chưa đăng kí dịch vụ này, vui lòng liên hệ Hỗ trợ để được tư vấn thêm",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 26,
+    "code": 224008,
+    "message": "Giao dịch rút tiền này đã bị huỷ",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 93,
+    "code": 224004,
+    "message": "Payment method not supported",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 23,
+    "code": 224004,
+    "message": "Phương thức thanh toán chưa được hỗ trợ",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 98,
+    "code": 224003,
+    "message": "Insufficient account balance",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 14,
+    "code": 224003,
+    "message": "Số dư tài khoản không đủ",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 28,
+    "code": 224010,
+    "message": "Tài khoản liên kết không chính xác",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 27,
+    "code": 224009,
+    "message": "Tài khoản thụ hưởng không hợp lệ",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 203,
+    "code": 224013,
+    "message": "OTP code has expired",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 204,
+    "code": 224013,
+    "message": "Mã xác thực đã hết hạn",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 207,
+    "code": 224002,
+    "message": "This voucher is not available",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 208,
+    "code": 224002,
+    "message": "Mã khuyến mãi không khả dụng",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 209,
+    "code": 224003,
+    "message": "This voucher is used up",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 210,
+    "code": 224003,
+    "message": "Mã khuyến mãi đã hết lượt sử dụng",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 211,
+    "code": 224001,
+    "message": "Transaction amount is below the minimum limit.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 212,
+    "code": 224001,
+    "message": "Số tiền nhỏ hơn mức tối thiểu.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 213,
+    "code": 224002,
+    "message": "Supplier code not found.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 214,
+    "code": 224002,
+    "message": "Không tìm thấy mã nhà cung cấp.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 215,
+    "code": 224003,
+    "message": "Insufficient account balance.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 216,
+    "code": 224003,
+    "message": "Số dư tài khoản không đủ.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 434,
+    "code": 224059,
+    "message": "Please try again",
+    "http_code": 409,
+    "locale": "en"
+  },
+  {
+    "id": 271,
+    "code": 224014,
+    "message": "Bank account request failed.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 272,
+    "code": 224014,
+    "message": "Yêu cầu liên kết tài khoản ngân hàng thất bại.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 273,
+    "code": 224015,
+    "message": "External service unavailable.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 274,
+    "code": 224015,
+    "message": "Dịch vụ bên ngoài không khả dụng.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 275,
+    "code": 224016,
+    "message": "Bank account already exists.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 276,
+    "code": 224016,
+    "message": "Tài khoản ngân hàng đã tồn tại.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 278,
+    "code": 224017,
+    "message": "Số tiền lớn hơn mức tối đa.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 277,
+    "code": 224017,
+    "message": "Transaction amount is above the maximum limit.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 279,
+    "code": 224018,
+    "message": "Only account owner can perform this action",
+    "http_code": 403,
+    "locale": "en"
+  },
+  {
+    "id": 280,
+    "code": 224018,
+    "message": "Chỉ chủ tài khoản mới có quyền thực hiện thao tác này",
+    "http_code": 403,
+    "locale": "vi"
+  },
+  {
+    "id": 281,
+    "code": 224019,
+    "message": "Account temporarily locked due to too many failed OTP attempts",
+    "http_code": 429,
+    "locale": "en"
+  },
+  {
+    "id": 282,
+    "code": 224019,
+    "message": "Tài khoản tạm thời bị khoá do nhập OTP sai quá nhiều lần",
+    "http_code": 429,
+    "locale": "vi"
+  },
+  {
+    "id": 283,
+    "code": 224020,
+    "message": "OTP resend limit exceeded. Please try again later",
+    "http_code": 429,
+    "locale": "en"
+  },
+  {
+    "id": 284,
+    "code": 224020,
+    "message": "Vượt quá số lần gửi lại OTP. Vui lòng thử lại sau",
+    "http_code": 429,
+    "locale": "vi"
+  },
+  {
+    "id": 285,
+    "code": 224021,
+    "message": "Only virtual accounts support person in charge management",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 286,
+    "code": 224021,
+    "message": "Chỉ tài khoản ảo mới hỗ trợ quản lý người phụ trách",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 287,
+    "code": 224024,
+    "message": "Account permanently locked due to too many failed OTP attempts. Please contact Customer Service for assistance.",
+    "http_code": 403,
+    "locale": "en"
+  },
+  {
+    "id": 288,
+    "code": 224024,
+    "message": "Tài khoản đã bị khóa vĩnh viễn do nhập sai OTP quá nhiều lần. Vui lòng liên hệ bộ phận Chăm sóc khách hàng để được hỗ trợ.",
+    "http_code": 403,
+    "locale": "vi"
+  },
+  {
+    "id": 435,
+    "code": 224059,
+    "message": "Vui lòng thử lại",
+    "http_code": 409,
+    "locale": "vi"
+  },
+  {
+    "id": 433,
+    "code": 224058,
+    "message": "Vui lòng cập nhật tài khoản ngân hàng trước khi gửi yêu cầu",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 387,
+    "code": 224035,
+    "message": "Spending limit not found",
+    "http_code": 404,
+    "locale": "en"
+  },
+  {
+    "id": 388,
+    "code": 224035,
+    "message": "Không tìm thấy hạn mức chi tiêu",
+    "http_code": 404,
+    "locale": "vi"
+  },
+  {
+    "id": 389,
+    "code": 224036,
+    "message": "Staff already has a spending limit for this account",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 390,
+    "code": 224036,
+    "message": "Nhân viên đã có hạn mức chi tiêu cho tài khoản này",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 391,
+    "code": 224037,
+    "message": "Spending limit is locked",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 392,
+    "code": 224037,
+    "message": "Hạn mức chi tiêu đã bị khóa",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 393,
+    "code": 224039,
+    "message": "Spending limit has been cancelled",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 394,
+    "code": 224039,
+    "message": "Hạn mức chi tiêu đã bị hủy",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 395,
+    "code": 224040,
+    "message": "Spending limit has expired",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 396,
+    "code": 224040,
+    "message": "Hạn mức chi tiêu đã hết hạn",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 397,
+    "code": 224041,
+    "message": "Cannot reduce limit below spent amount",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 398,
+    "code": 224041,
+    "message": "Không thể giảm hạn mức thấp hơn số tiền đã chi",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 399,
+    "code": 224042,
+    "message": "Bank does not support spending limit feature",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 400,
+    "code": 224042,
+    "message": "Ngân hàng không hỗ trợ tính năng hạn mức chi tiêu",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 401,
+    "code": 224038,
+    "message": "Spending limit was locked by another user",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 402,
+    "code": 224038,
+    "message": "Tài khoản chi tiêu đã bị khoá bởi người khác",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 403,
+    "code": 224043,
+    "message": "Only owner or assigned staff can lock/unlock",
+    "http_code": 403,
+    "locale": "en"
+  },
+  {
+    "id": 404,
+    "code": 224043,
+    "message": "Chỉ chủ doanh nghiệp hoặc nhân viên được gán mới có thể khoá/mở khoá",
+    "http_code": 403,
+    "locale": "vi"
+  },
+  {
+    "id": 405,
+    "code": 224044,
+    "message": "Spending limit exceeded",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 406,
+    "code": 224044,
+    "message": "Vượt quá hạn mức còn lại",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 407,
+    "code": 224045,
+    "message": "Transaction count limit reached",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 408,
+    "code": 224045,
+    "message": "Tài khoản đã tới giới hạn số lượng giao dịch",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 409,
+    "code": 224046,
+    "message": "Beneficiary account not in whitelist",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 410,
+    "code": 224046,
+    "message": "Tài khoản nhận tiền không nằm trong danh sách được phép",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 411,
+    "code": 224046,
+    "message": "Spending Limit Exceeded",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 412,
+    "code": 224048,
+    "message": "Invalid Recipient Account",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 413,
+    "code": 224048,
+    "message": "Tài khoản nhận tiền không phù hợp",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 414,
+    "code": 224049,
+    "message": "Insufficient Balance",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 415,
+    "code": 224049,
+    "message": "Không đủ số dư",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 416,
+    "code": 224050,
+    "message": "Spending limit request already processed",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 417,
+    "code": 224050,
+    "message": "Yêu cầu định mức đã được xử lý",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 418,
+    "code": 224051,
+    "message": "Spending limit request is not pending",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 419,
+    "code": 224051,
+    "message": "Yêu cầu định mức không ở trạng thái chờ duyệt",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 420,
+    "code": 224052,
+    "message": "You are not the requester",
+    "http_code": 403,
+    "locale": "en"
+  },
+  {
+    "id": 421,
+    "code": 224052,
+    "message": "Bạn không phải người tạo yêu cầu này",
+    "http_code": 403,
+    "locale": "vi"
+  },
+  {
+    "id": 422,
+    "code": 224053,
+    "message": "A pending adjustment request already exists",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 423,
+    "code": 224053,
+    "message": "Đã có yêu cầu điều chỉnh đang chờ duyệt",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 424,
+    "code": 224054,
+    "message": "Spending limit is not active",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 425,
+    "code": 224054,
+    "message": "Định mức chi tiêu không còn hiệu lực để điều chỉnh",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 426,
+    "code": 224055,
+    "message": "Reimbursement not found",
+    "http_code": 404,
+    "locale": "en"
+  },
+  {
+    "id": 427,
+    "code": 224055,
+    "message": "Không tìm thấy yêu cầu thanh toán",
+    "http_code": 404,
+    "locale": "vi"
+  },
+  {
+    "id": 428,
+    "code": 224056,
+    "message": "Invalid reimbursement status for this action",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 429,
+    "code": 224056,
+    "message": "Trạng thái yêu cầu thanh toán không hợp lệ",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 430,
+    "code": 224057,
+    "message": "Only the creator can perform this action",
+    "http_code": 403,
+    "locale": "en"
+  },
+  {
+    "id": 431,
+    "code": 224057,
+    "message": "Bạn không có quyền thực hiện thao tác này",
+    "http_code": 403,
+    "locale": "vi"
+  },
+  {
+    "id": 432,
+    "code": 224058,
+    "message": "Please add a bank account before submitting",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 436,
+    "code": 224060,
+    "message": "Business owner not found",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 437,
+    "code": 224060,
+    "message": "Không tìm thấy chủ doanh nghiệp",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 438,
+    "code": 224062,
+    "message": "Staff bank account not found",
+    "http_code": 404,
+    "locale": "en"
+  },
+  {
+    "id": 439,
+    "code": 224062,
+    "message": "Không tìm thấy tài khoản ngân hàng nhân viên",
+    "http_code": 404,
+    "locale": "vi"
+  },
+  {
+    "id": 450,
+    "code": 224090,
+    "message": "Invalid configuration for one-time use spending limit.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 451,
+    "code": 224090,
+    "message": "Cấu hình định mức Dùng 1 lần không hợp lệ.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 452,
+    "code": 224091,
+    "message": "Spending limit has already been used and is no longer active.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 453,
+    "code": 224091,
+    "message": "Định mức đã được sử dụng và không còn hiệu lực.",
+    "http_code": 400,
+    "locale": "vi"
+  },
+  {
+    "id": 454,
+    "code": 224092,
+    "message": "Cannot edit configuration of a one-time use spending limit.",
+    "http_code": 400,
+    "locale": "en"
+  },
+  {
+    "id": 455,
+    "code": 224092,
+    "message": "Không thể chỉnh sửa cấu hình của định mức Dùng 1 lần.",
+    "http_code": 400,
+    "locale": "vi"
+  }
+]

--- a/config/messagecode/embed.go
+++ b/config/messagecode/embed.go
@@ -1,0 +1,6 @@
+package messagecode
+
+import _ "embed"
+
+//go:embed catalog/message_codes.json
+var messageCodesJSON []byte

--- a/config/messagecode/fetch.go
+++ b/config/messagecode/fetch.go
@@ -6,55 +6,27 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"code.finan.one/finan-one-be/fo-utils/net/uthttp"
-	"code.finan.one/finan-one-be/fo-utils/utils/utfunc"
 	redis "github.com/redis/go-redis/v9"
-	"gitlab.com/goxp/cloud0/logger"
 )
 
-const (
-	generalGroup = 10
-
-	messageGroupEmptyKey = "empty"
-)
+const generalGroup = 10
 
 type messageCode struct {
 	HTTPCode int    `json:"http_code"`
 	Message  string `json:"messasge"`
 }
 
-type strapiMessageCodeResp struct {
-	Data  []strapiMessageCode `json:"data"`
-	Error struct {
-		Status  int                    `json:"status"`
-		Name    string                 `json:"name"`
-		Message string                 `json:"message"`
-		Details ValidationErrorDetails `json:"details"`
-	} `json:"error"`
-	Meta strapiMeta `json:"meta"`
-}
-
-type strapiMessageCode struct {
+type fileMessageCode struct {
 	ID       int    `json:"id"`
 	Code     int    `json:"code"`
 	Locale   string `json:"locale"`
 	Message  string `json:"message"`
 	HTTPCode int    `json:"http_code"`
-}
-
-type strapiMeta struct {
-	Pagination strapiPagination `json:"pagination"`
-}
-
-type strapiPagination struct {
-	Page      int `json:"page"`
-	PageSize  int `json:"pageSize"`
-	PageCount int `json:"pageCount"`
-	Total     int `json:"total"`
 }
 
 type Config struct {
@@ -85,10 +57,7 @@ func NewClient(cfg Config) (*Client, error) {
 		messageMap: map[string]messageCode{},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	err := client.LoadMessageCode(ctx, cfg.MessageGroup...)
-	if err != nil {
+	if err := client.LoadMessageCode(context.Background(), cfg.MessageGroup...); err != nil {
 		return nil, err
 	}
 
@@ -113,109 +82,48 @@ func (c *Client) GetHTTPCode(locale string, code int) int {
 	return messCode.HTTPCode
 }
 
-// Load messages from redis if cache hit or from strapi if cache miss. Ignore all error.
-func (c *Client) LoadMessageCode(ctx context.Context, messageGroups ...int) error {
-	log := logger.WithCtx(ctx, utfunc.GetCurrentCaller(c, 0))
+// LoadMessageCode loads catalog entries from the embedded JSON file.
+// Duplicate locale+code pairs keep the last occurrence, matching previous Strapi merge order.
+func (c *Client) LoadMessageCode(_ context.Context, messageGroups ...int) error {
+	codes, err := loadEmbeddedMessageCodes()
+	if err != nil {
+		return err
+	}
 
-	messageGroups = append(messageGroups, generalGroup)
-	for _, group := range messageGroups {
-		key := makeHashKey(group)
-		//messageGroupRes, err := c.redisCli.HGetAll(ctx, key).Result()
-		//var cacheHit bool
-		//if err != nil {
-		//	log.WithError(err).Errorf("Failed to get message codes of group %d from redis", group)
-		//	cacheHit = false
-		//	err = nil
-		//} else if len(messageGroupRes) == 0 {
-		//	cacheHit = false
-		//} else {
-		//	cacheHit = true
-		//}
-		//if cacheHit {
-		//	messageStrMap := messageGroupRes
-		//	_, ok := messageStrMap[messageGroupEmptyKey]
-		//	if ok {
-		//		continue
-		//	}
-		//	messageCodeMap, err := byteMapToMessageCodeMap(messageStrMap)
-		//	if err != nil {
-		//		return err
-		//	}
-		//
-		//	c.mergeMessageCodesMap(messageCodeMap)
-		//} else {
-		messageCodeMap, err := c.getMessageGroupMapFromStrapi(ctx, group)
-		if err != nil {
-			log.WithError(err).Errorf("Failed to get message codes of group %d from strapi", group)
+	groups := append([]int{}, messageGroups...)
+	groups = append(groups, generalGroup)
+
+	messageCodeMap := make(map[string]messageCode, len(codes))
+	for _, messCode := range codes {
+		if !codeBelongsToGroups(messCode.Code, groups) {
 			continue
 		}
-
-		if len(messageCodeMap) == 0 {
-			messageCodeMap[messageGroupEmptyKey] = messageCode{}
-		}
-
-		anyMap, err := messageMapToAnyMap(messageCodeMap)
-		if err != nil {
-			return err
-		}
-
-		_ = c.redisCli.HMSet(ctx, key, anyMap)
-
-		c.mergeMessageCodesMap(messageCodeMap)
-		//}
-	}
-
-	return nil
-}
-
-func (c *Client) getMessageGroupMapFromStrapi(ctx context.Context, messageGroup int) (map[string]messageCode, error) {
-	res := map[string]messageCode{}
-	messageCodes, err := c.getStrapiMessageCodes(ctx, messageGroup)
-	if err != nil {
-		return nil, err
-	}
-	for _, messCode := range messageCodes {
-		res[makeFieldKey(messCode.Locale, messCode.Code)] = messageCode{
+		messageCodeMap[makeFieldKey(messCode.Locale, messCode.Code)] = messageCode{
 			HTTPCode: messCode.HTTPCode,
 			Message:  messCode.Message,
 		}
 	}
 
-	return res, nil
+	c.mergeMessageCodesMap(messageCodeMap)
+	return nil
 }
 
-func messageMapToAnyMap(messageMap map[string]messageCode) (map[string]any, error) {
-	byteMap := make(map[string]any, len(messageMap))
-
-	for key, val := range messageMap {
-		blob, err := json.Marshal(val)
-		if err != nil {
-			return nil, err
-		}
-
-		byteMap[key] = blob
+func loadEmbeddedMessageCodes() ([]fileMessageCode, error) {
+	var codes []fileMessageCode
+	if err := json.Unmarshal(messageCodesJSON, &codes); err != nil {
+		return nil, fmt.Errorf("parse embedded message_codes.json: %w", err)
 	}
-
-	return byteMap, nil
+	return codes, nil
 }
 
-func byteMapToMessageCodeMap(byteMap map[string]string) (map[string]messageCode, error) {
-	messsageCodeMap := make(map[string]messageCode, len(byteMap))
-	for key, val := range byteMap {
-		var messCode messageCode
-		err := json.Unmarshal([]byte(val), &messCode)
-		if err != nil {
-			return nil, err
+func codeBelongsToGroups(code int, groups []int) bool {
+	codeStr := strconv.Itoa(code)
+	for _, group := range groups {
+		if strings.HasPrefix(codeStr, strconv.Itoa(group)) {
+			return true
 		}
-
-		messsageCodeMap[key] = messCode
 	}
-
-	return messsageCodeMap, nil
-}
-
-func makeHashKey(messageGroup int) string {
-	return fmt.Sprintf("messagegroup:%d", messageGroup)
+	return false
 }
 
 func makeFieldKey(locale string, messageCode int) string {
@@ -237,56 +145,6 @@ func fallbackMessageCodeToHTTPCode(code int) int {
 	default:
 		return http.StatusInternalServerError
 	}
-}
-
-func (c *Client) getStrapiMessageCodes(ctx context.Context, messageGroup int) ([]strapiMessageCode, error) {
-	totalPage := 1
-	page := 1
-	uri, err := url.Parse(c.cfg.StrapiMessageCodeURL)
-	if err != nil {
-		return nil, err
-	}
-	var messageCodes []strapiMessageCode
-	for page <= totalPage {
-		queryVals := uri.Query()
-		queryVals.Set("pagination[page]", fmt.Sprintf("%d", page))
-		queryVals.Set("pagination[pageSize]", "300")
-		queryVals.Set("locale", "all")
-		queryVals.Set("filters[code][$startsWithi]", strconv.Itoa(messageGroup))
-		uri.RawQuery = queryVals.Encode()
-
-		req := uthttp.HTTPRequest{
-			Method: http.MethodGet,
-			URL:    uri.String(),
-			Silent: true,
-			Header: map[string]string{
-				"Authorization": fmt.Sprintf("Bearer %s", c.cfg.StrapiToken),
-			},
-		}
-		cfg := uthttp.Config{
-			Timeout: 3 * time.Second,
-		}
-
-		client := uthttp.NewHTTPClient(cfg)
-
-		resp, err := uthttp.SendHTTPRequest[strapiMessageCodeResp](ctx, client, req, uthttp.DefaultOptions())
-		if err != nil {
-			return nil, err
-		}
-
-		if resp.StatusCode >= 400 {
-			return nil, fmt.Errorf("get message codes from strapi status code: %d", resp.StatusCode)
-		}
-
-		body := resp.Body
-
-		messageCodes = append(messageCodes, body.Data...)
-
-		totalPage = body.Meta.Pagination.PageCount
-		page++
-	}
-
-	return messageCodes, nil
 }
 
 func (c *Client) mergeMessageCodesMap(messageMap map[string]messageCode) {

--- a/config/messagecode/fetch_test.go
+++ b/config/messagecode/fetch_test.go
@@ -1,0 +1,62 @@
+package messagecode
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestLoadEmbeddedJSON(t *testing.T) {
+	codes, err := loadEmbeddedMessageCodes()
+	if err != nil {
+		t.Fatalf("unmarshal catalog: %v", err)
+	}
+	if len(codes) != 132 {
+		t.Fatalf("catalog size: got %d want 132", len(codes))
+	}
+}
+
+func TestGetMessageFromJSON(t *testing.T) {
+	c := &Client{messageMap: map[string]messageCode{}}
+	if err := c.LoadMessageCode(context.Background(), 22); err != nil {
+		t.Fatalf("LoadMessageCode: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		locale   string
+		code     int
+		wantMsg  string
+		wantHTTP int
+	}{
+		{"success vi", "vi", GeneralSuccessCode, "Thực thi API thành công", http.StatusOK},
+		{"bad request vi", "vi", GeneralBadRequestCode, "Yêu cầu không hợp lệ", http.StatusBadRequest},
+		{"bad request en", "en", GeneralBadRequestCode, "Invalid request", http.StatusBadRequest},
+		{"unauthorized last-write en", "en", GeneralUnauthorizedCode, "Request denied", http.StatusUnauthorized},
+		{"unauthorized last-write vi", "vi", GeneralUnauthorizedCode, "Xác thực không thành công", http.StatusUnauthorized},
+		{"group 22", "vi", 224055, "Không tìm thấy yêu cầu thanh toán", http.StatusNotFound},
+		{"missing code", "vi", 999999, "Không tìm thấy message", http.StatusInternalServerError},
+		{"success en missing in catalog", "en", GeneralSuccessCode, "Message not found", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.GetMessage(tt.locale, tt.code); got != tt.wantMsg {
+				t.Errorf("GetMessage = %q want %q", got, tt.wantMsg)
+			}
+			if got := c.GetHTTPCode(tt.locale, tt.code); got != tt.wantHTTP {
+				t.Errorf("GetHTTPCode = %d want %d", got, tt.wantHTTP)
+			}
+		})
+	}
+}
+
+func TestNewClientDoesNotNeedStrapi(t *testing.T) {
+	client, err := NewClient(Config{MessageGroup: []int{22}})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if got := client.GetMessage("vi", 102000); got != "Thực thi API thành công" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
- Introduced a new package for message codes with embedded JSON support.
- Added `embed.go` to load message codes from `catalog/message_codes.json`.
- Created `fetch_test.go` to validate loading and retrieval of messages.
- Removed unused Strapi-related code from `fetch.go` to streamline message loading logic.